### PR TITLE
상태관리5개 수정(1가지로->따른데이터바인딩) + 상품리스트 스크롤시 상품추가

### DIFF
--- a/shopping/package-lock.json
+++ b/shopping/package-lock.json
@@ -23,6 +23,7 @@
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.11.1",
         "react-scripts": "5.0.1",
+        "redux-persist": "^6.0.0",
         "web-vitals": "^2.1.4"
       }
     },
@@ -17896,6 +17897,14 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
       }
     },
     "node_modules/redux-thunk": {

--- a/shopping/package.json
+++ b/shopping/package.json
@@ -18,6 +18,7 @@
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.11.1",
     "react-scripts": "5.0.1",
+    "redux-persist": "^6.0.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/shopping/src/component/Item.js
+++ b/shopping/src/component/Item.js
@@ -1,25 +1,24 @@
 import React from 'react';
 import './Item.css';
+import { useSelector, useDispatch } from 'react-redux';
+import { addToBookmark, removeFromBookmark } from '../store';
 
 function Item(props) {
   const { id } = props;
   const bookmarkedItems = JSON.parse(localStorage.getItem('bookmarkedItems')) || [];
 
   const existingItem = bookmarkedItems.find((item) => item.id === id);
-  
-  
-
+  const bookmark = useSelector((state) => state.bookmark);
+  const dispatch = useDispatch();
 
   const handleBookmark = () => {
-    
-
     const bookmarkedItems = JSON.parse(localStorage.getItem('bookmarkedItems')) || [];
-
     const existingItem = bookmarkedItems.find((item) => item.id === id); // 이미 추가된 아이템인지 확인
 
     if (existingItem) {
       const updatedItems = bookmarkedItems.filter((item) => item.id !== id);
       localStorage.setItem('bookmarkedItems', JSON.stringify(updatedItems));
+      dispatch(removeFromBookmark(id));
       console.log('제거되었습니다.');
     } else {
       const newItem = {
@@ -36,6 +35,7 @@ function Item(props) {
       };
       bookmarkedItems.push(newItem);
       localStorage.setItem('bookmarkedItems', JSON.stringify(bookmarkedItems));
+      dispatch(addToBookmark(newItem));
       console.log('추가되었습니다.');
     }
   };
@@ -46,15 +46,19 @@ function Item(props) {
         <div className="image-wrapper">
           <img className="image" src={props.image_url || props.brand_image_url} alt="대체이미지" />
         </div>
-        <div className="bookmark-wrapper"> 
-          <button className='bookmark-button' onClick={handleBookmark}>
-          <i className={`fas fa-star ${ existingItem? 'custom-star' : ''}`}></i>
+        <div className="bookmark-wrapper">
+          <button className="bookmark-button" onClick={handleBookmark}>
+            <i className={`fas fa-star ${existingItem ? 'custom-star' : ''}`}></i>
           </button>
         </div>
       </div>
       <div className="first-line">
         <div className="item-title">
-          {props.type === 'Brand' ? props.brand_name : props.type === 'Category' ? '#' + props.title : props.title}
+          {props.type === 'Brand'
+            ? props.brand_name
+            : props.type === 'Category'
+            ? '#' + props.title
+            : props.title}
         </div>
         <div className="right-elemnt">
           {props.type === 'Product' ? props.discountPercentage + '%' : null}
@@ -68,6 +72,3 @@ function Item(props) {
 }
 
 export default Item;
-
-
-

--- a/shopping/src/component/filter.js
+++ b/shopping/src/component/filter.js
@@ -1,45 +1,45 @@
-import './filter.css'
+import React from 'react';
+import './filter.css';
 
+function Filter({ type, setType }) {
+  const stateClickhandler = (selectedType) => {
+    setType(selectedType);
+  };
 
-function Filter({ 전체, set전체, 상품, set상품, 카테고리, set카테고리, 기획전, set기획전, 브랜드, set브랜드 }) {
-    
-
-    const stateClickhandler = (stateSetter) => () => {
-        set전체(false);
-        set상품(false);
-        set카테고리(false);
-        set기획전(false);
-        set브랜드(false);
-        stateSetter(true);
-      };
-    
-      
-
-    return (
-        <div className="Filter">
-            <div className="Filter__list"> 
-            <img src={process.env.PUBLIC_URL + ('/전체.png')} alt="전체"/> 
-            <div className={전체===true?'Filter__discription':null} onClick={stateClickhandler(set전체)}>전체</div>
-            </div>
-            <div className="Filter__list"> 
-            <img src={process.env.PUBLIC_URL + ('/상품.png')} alt="상품"/> 
-            <div className={상품===true?'Filter__discription':null} onClick={stateClickhandler(set상품)}>상품</div>
-            </div>
-            <div className="Filter__list"> 
-            <img src={process.env.PUBLIC_URL + ('/카테고리.png')} alt="카테고리"/> 
-            <div className={카테고리===true?'Filter__discription':null} onClick={stateClickhandler(set카테고리)}>카테고리</div>
-            </div>
-            <div className="Filter__list"> 
-            <img src={process.env.PUBLIC_URL + ('/기획전.png')} alt="기획전"/> 
-            <div className={기획전===true?'Filter__discription':null} onClick={stateClickhandler(set기획전)}>기획전</div>
-            </div> 
-            <div className="Filter__list"> 
-            <img src={process.env.PUBLIC_URL + ('/브랜드.png')} alt="브랜드"/> 
-            <div className={브랜드===true?'Filter__discription':null} onClick={stateClickhandler(set브랜드)}>브랜드</div>
-            </div>
-            
+  return (
+    <div className="Filter">
+      <div className="Filter__list">
+        <img src={process.env.PUBLIC_URL + '/전체.png'} alt="전체" />
+        <div className={type === null ? 'Filter__discription' : null} onClick={() => stateClickhandler(null)}>
+          전체
         </div>
-      );
+      </div>
+      <div className="Filter__list">
+        <img src={process.env.PUBLIC_URL + '/상품.png'} alt="상품" />
+        <div className={type === 'Product' ? 'Filter__discription' : null} onClick={() => stateClickhandler('Product')}>
+          상품
+        </div>
+      </div>
+      <div className="Filter__list">
+        <img src={process.env.PUBLIC_URL + '/카테고리.png'} alt="카테고리" />
+        <div className={type === 'Category' ? 'Filter__discription' : null} onClick={() => stateClickhandler('Category')}>
+          카테고리
+        </div>
+      </div>
+      <div className="Filter__list">
+        <img src={process.env.PUBLIC_URL + '/기획전.png'} alt="기획전" />
+        <div className={type === 'Exhibition' ? 'Filter__discription' : null} onClick={() => stateClickhandler('Exhibition')}>
+          기획전
+        </div>
+      </div>
+      <div className="Filter__list">
+        <img src={process.env.PUBLIC_URL + '/브랜드.png'} alt="브랜드" />
+        <div className={type === 'Brand' ? 'Filter__discription' : null} onClick={() => stateClickhandler('Brand')}>
+          브랜드
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default Filter;

--- a/shopping/src/index.js
+++ b/shopping/src/index.js
@@ -7,6 +7,7 @@ import { BrowserRouter } from "react-router-dom";
 import { Provider } from "react-redux";
 import store from './store';
 
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>

--- a/shopping/src/page/Bookmark.js
+++ b/shopping/src/page/Bookmark.js
@@ -1,53 +1,73 @@
-import './Bookmark.css';
-import { useState, useEffect } from 'react';
+import './Bookmark.css'
+import { useState } from 'react';
 import Item from '../component/Item';
+import { useEffect } from 'react';
 import Filter from '../component/filter';
 
 function Bookmark() {
-  const [bookmarkedItems, setBookmarkedItems] = useState([]);
-  const [filteredData, setFilteredData] = useState([]);
-  const [type, setType] = useState(null);
-
-  useEffect(() => {
-    const localStorageData = localStorage.getItem('bookmarkedItems');
-    if (localStorageData) {
-      setBookmarkedItems(JSON.parse(localStorageData));
-    }
-  }, []);
-
-  const filterItemsByType = (type) => {
-    return bookmarkedItems.filter((item) => item.type === type);
-  };
-
-  const getRandomItems = (array, numItems) => {
-    const shuffled = array.sort(() => 0.5 - Math.random());
-    return shuffled.slice(0, numItems);
-  };
-
-  useEffect(() => {
-    if (type === 'Product' || type === 'Category' || type === 'Exhibition' || type === 'Brand') {
+    const [bookmarkedItems, setBookmarkedItems] = useState([]);
+    const [randomData, setRandomData] = useState([]);
+    const [type,setType]=useState(null)
+  
+    useEffect(() => {
+      // localStorage에서 데이터 가져오기
+      const localStorageData = localStorage.getItem('bookmarkedItems');
+      if (localStorageData) {
+        setBookmarkedItems(JSON.parse(localStorageData));
+      }
+    }, []);
+  
+    // 상품 필터링 함수
+    const filterItemsByType = (type) => {
+      return bookmarkedItems.filter((item) => item.type === type);
+    };
+  
+    // 필터링된 아이템들을 랜덤하게 선택하여 반환
+    const getRandomItems = (array, numItems) => {
+      const shuffled = array.sort(() => 0.5 - Math.random());
+      return shuffled.slice(0, numItems);
+    };
+  
+    
+  
+    useEffect(() => {
+      if (type==='product') {
+        setFilteredRandomData('Product');
+      } else if (type==='category') {
+        setFilteredRandomData('Category');
+      } else if (type==='exhibition') {
+        setFilteredRandomData('Exhibition');
+      } else if (type==='brand') {
+        setFilteredRandomData('Brand');
+      } else {
+        // 전체일 때는 모든 북마크 아이템을 보여줌
+        setRandomData(getRandomItems(bookmarkedItems, 100));
+      }
+    }, [type, bookmarkedItems]);
+  
+    // 필터링된 아이템들을 랜덤하게 선택하여 설정
+    const setFilteredRandomData = (type) => {
       const filteredItems = filterItemsByType(type);
       const randomItems = getRandomItems(filteredItems, 100);
-      setFilteredData(randomItems);
-    } else {
-      const randomItems = getRandomItems(bookmarkedItems, 100);
-      setFilteredData(randomItems);
+      setRandomData(randomItems);
+    };
+  
+    return (
+      <div>
+        <Filter
+          type={type} setType={setType}
+        />
+        <ul className="itemlist">
+          {randomData.map((item) => (
+            <Item key={item.id} {...item} />
+          ))}    </ul>
+
+          <button onClick={() => console.log(bookmarkedItems)}>확인</button>
+        </div>
+      );
     }
-  }, [type, bookmarkedItems]);
+    
+    export default Bookmark;
 
-  return (
-    <div>
-      <Filter type={type} setType={setType} />
-      <ul className="itemlist">
-        {filteredData.map((item) => (
-          <Item key={item.id} {...item} />
-        ))}
-      </ul>
-      <button onClick={() => console.log(bookmarkedItems)}>확인</button>
-    </div>
-  );
-}
-
-export default Bookmark;
 
 

--- a/shopping/src/page/Bookmark.js
+++ b/shopping/src/page/Bookmark.js
@@ -1,73 +1,53 @@
-import './Bookmark.css'
-import { useState } from 'react';
+import './Bookmark.css';
+import { useState, useEffect } from 'react';
 import Item from '../component/Item';
-import { useEffect } from 'react';
 import Filter from '../component/filter';
 
 function Bookmark() {
-    const [bookmarkedItems, setBookmarkedItems] = useState([]);
-    const [randomData, setRandomData] = useState([]);
-    const [type,setType]=useState(null)
-  
-    useEffect(() => {
-      // localStorage에서 데이터 가져오기
-      const localStorageData = localStorage.getItem('bookmarkedItems');
-      if (localStorageData) {
-        setBookmarkedItems(JSON.parse(localStorageData));
-      }
-    }, []);
-  
-    // 상품 필터링 함수
-    const filterItemsByType = (type) => {
-      return bookmarkedItems.filter((item) => item.type === type);
-    };
-  
-    // 필터링된 아이템들을 랜덤하게 선택하여 반환
-    const getRandomItems = (array, numItems) => {
-      const shuffled = array.sort(() => 0.5 - Math.random());
-      return shuffled.slice(0, numItems);
-    };
-  
-    
-  
-    useEffect(() => {
-      if (type==='product') {
-        setFilteredRandomData('Product');
-      } else if (type==='category') {
-        setFilteredRandomData('Category');
-      } else if (type==='exhibition') {
-        setFilteredRandomData('Exhibition');
-      } else if (type==='brand') {
-        setFilteredRandomData('Brand');
-      } else {
-        // 전체일 때는 모든 북마크 아이템을 보여줌
-        setRandomData(getRandomItems(bookmarkedItems, 100));
-      }
-    }, [type, bookmarkedItems]);
-  
-    // 필터링된 아이템들을 랜덤하게 선택하여 설정
-    const setFilteredRandomData = (type) => {
+  const [bookmarkedItems, setBookmarkedItems] = useState([]);
+  const [filteredData, setFilteredData] = useState([]);
+  const [type, setType] = useState(null);
+
+  useEffect(() => {
+    const localStorageData = localStorage.getItem('bookmarkedItems');
+    if (localStorageData) {
+      setBookmarkedItems(JSON.parse(localStorageData));
+    }
+  }, []);
+
+  const filterItemsByType = (type) => {
+    return bookmarkedItems.filter((item) => item.type === type);
+  };
+
+  const getRandomItems = (array, numItems) => {
+    const shuffled = array.sort(() => 0.5 - Math.random());
+    return shuffled.slice(0, numItems);
+  };
+
+  useEffect(() => {
+    if (type === 'Product' || type === 'Category' || type === 'Exhibition' || type === 'Brand') {
       const filteredItems = filterItemsByType(type);
       const randomItems = getRandomItems(filteredItems, 100);
-      setRandomData(randomItems);
-    };
-  
-    return (
-      <div>
-        <Filter
-          type={type} setType={setType}
-        />
-        <ul className="itemlist">
-          {randomData.map((item) => (
-            <Item key={item.id} {...item} />
-          ))}    </ul>
-
-          <button onClick={() => console.log(bookmarkedItems)}>확인</button>
-        </div>
-      );
+      setFilteredData(randomItems);
+    } else {
+      const randomItems = getRandomItems(bookmarkedItems, 100);
+      setFilteredData(randomItems);
     }
-    
-    export default Bookmark;
+  }, [type, bookmarkedItems]);
 
+  return (
+    <div>
+      <Filter type={type} setType={setType} />
+      <ul className="itemlist">
+        {filteredData.map((item) => (
+          <Item key={item.id} {...item} />
+        ))}
+      </ul>
+      <button onClick={() => console.log(bookmarkedItems)}>확인</button>
+    </div>
+  );
+}
+
+export default Bookmark;
 
 

--- a/shopping/src/page/Bookmark.js
+++ b/shopping/src/page/Bookmark.js
@@ -2,9 +2,12 @@ import './Bookmark.css'
 import { useState } from 'react';
 import Item from '../component/Item';
 import { useEffect } from 'react';
+import Filter from '../component/filter';
 
 function Bookmark() {
     const [bookmarkedItems, setBookmarkedItems] = useState([]);
+    const [randomData, setRandomData] = useState([]);
+    const [type,setType]=useState(null)
   
     useEffect(() => {
       // localStorage에서 데이터 가져오기
@@ -25,27 +28,22 @@ function Bookmark() {
       return shuffled.slice(0, numItems);
     };
   
-    const [전체, set전체] = useState(false);
-    const [상품, set상품] = useState(false);
-    const [카테고리, set카테고리] = useState(false);
-    const [기획전, set기획전] = useState(false);
-    const [브랜드, set브랜드] = useState(false);
-    const [randomData, setRandomData] = useState([]);
+    
   
     useEffect(() => {
-      if (상품) {
+      if (type==='product') {
         setFilteredRandomData('Product');
-      } else if (카테고리) {
+      } else if (type==='category') {
         setFilteredRandomData('Category');
-      } else if (기획전) {
+      } else if (type==='exhibition') {
         setFilteredRandomData('Exhibition');
-      } else if (브랜드) {
+      } else if (type==='brand') {
         setFilteredRandomData('Brand');
       } else {
         // 전체일 때는 모든 북마크 아이템을 보여줌
         setRandomData(getRandomItems(bookmarkedItems, 100));
       }
-    }, [상품, 카테고리, 기획전, 브랜드, bookmarkedItems]);
+    }, [type, bookmarkedItems]);
   
     // 필터링된 아이템들을 랜덤하게 선택하여 설정
     const setFilteredRandomData = (type) => {
@@ -57,16 +55,7 @@ function Bookmark() {
     return (
       <div>
         <Filter
-          전체={전체}
-          set전체={set전체}
-          상품={상품}
-          set상품={set상품}
-          카테고리={카테고리}
-          set카테고리={set카테고리}
-          기획전={기획전}
-          set기획전={set기획전}
-          브랜드={브랜드}
-          set브랜드={set브랜드}
+          type={type} setType={setType}
         />
         <ul className="itemlist">
           {randomData.map((item) => (
@@ -82,44 +71,3 @@ function Bookmark() {
 
 
 
-function Filter({전체,set전체,상품,set상품,카테고리,set카테고리,기획전,set기획전,브랜드,set브랜드}) {
-   
-    
-
-    const stateClickhandler = (stateSetter) => () => {
-        set전체(false);
-        set상품(false);
-        set카테고리(false);
-        set기획전(false);
-        set브랜드(false);
-        stateSetter(true);
-      };
-    
-      
-
-    return (
-        <div className="Filter">
-            <div className="Filter__list"> 
-            <img src={process.env.PUBLIC_URL + ('/전체.png')} alt="전체"/> 
-            <div className={전체===true?'Filter__discription':null} onClick={stateClickhandler(set전체)}>전체</div>
-            </div>
-            <div className="Filter__list"> 
-            <img src={process.env.PUBLIC_URL + ('/상품.png')} alt="상품"/> 
-            <div className={상품===true?'Filter__discription':null} onClick={stateClickhandler(set상품)}>상품</div>
-            </div>
-            <div className="Filter__list"> 
-            <img src={process.env.PUBLIC_URL + ('/카테고리.png')} alt="카테고리"/> 
-            <div className={카테고리===true?'Filter__discription':null} onClick={stateClickhandler(set카테고리)}>카테고리</div>
-            </div>
-            <div className="Filter__list"> 
-            <img src={process.env.PUBLIC_URL + ('/기획전.png')} alt="기획전"/> 
-            <div className={기획전===true?'Filter__discription':null} onClick={stateClickhandler(set기획전)}>기획전</div>
-            </div> 
-            <div className="Filter__list"> 
-            <img src={process.env.PUBLIC_URL + ('/브랜드.png')} alt="브랜드"/> 
-            <div className={브랜드===true?'Filter__discription':null} onClick={stateClickhandler(set브랜드)}>브랜드</div>
-            </div>
-            
-        </div>
-      );
-}

--- a/shopping/src/page/Product.js
+++ b/shopping/src/page/Product.js
@@ -5,87 +5,80 @@ import Item from '../component/Item';
 import './Product.css';
 
 function Product() {
-  const [wholedata, setWholedata] = useState([]);
-  const [전체, set전체] = useState(false);
-  const [상품, set상품] = useState(false);
-  const [카테고리, set카테고리] = useState(false);
-  const [기획전, set기획전] = useState(false);
-  const [브랜드, set브랜드] = useState(false);
-  const [randomData, setRandomData] = useState([]);
+  const [wholedata, setWholedata] = useState(() => {
+    const storedData = localStorage.getItem('wholedata');
+    return storedData ? JSON.parse(storedData) : [];
+  });
+
+  const [type, setType] = useState(null);
+  const [scrollvalue, setScrollvalue] = useState(12);
 
   useEffect(() => {
     async function fetchData() {
       try {
         const response = await axios.get('http://cozshopping.codestates-seb.link/api/v1/products?count=');
-        setWholedata(response.data);
-
-        // 12개의 랜덤 데이터 선택
-        const randomItems = getRandomItems(response.data, 100);
-        setRandomData(randomItems);
+        const data = response.data;
+        setWholedata(data);
+        localStorage.setItem('wholedata', JSON.stringify(data));
       } catch (error) {
         console.error(error);
       } finally {
-        console.log('로딩끝');
+        console.log('로딩 끝');
       }
     }
     fetchData();
   }, []);
 
-  // 배열에서 랜덤하게 numItems 개수 만큼 아이템을 선택하는 함수
   const getRandomItems = (array, numItems) => {
     const shuffled = array.sort(() => 0.5 - Math.random());
     return shuffled.slice(0, numItems);
   };
 
-  // 특정 타입에 해당하는 상품들 필터링
   const filterItemsByType = (type) => {
     return wholedata.filter((item) => item.type === type);
   };
 
-  // 필터링된 아이템들을 랜덤하게 선택하여 설정
-  const setFilteredRandomData = (type) => {
-    const filteredItems = filterItemsByType(type);
-    const randomItems = getRandomItems(filteredItems, 100);
-    setRandomData(randomItems);
-  };
+  
 
   useEffect(() => {
-    if (상품) {
-      setFilteredRandomData('Product');
-    } else if (카테고리) {
-      setFilteredRandomData('Category');
-    } else if (기획전) {
-      setFilteredRandomData('Exhibition');
-    } else if (브랜드) {
-      setFilteredRandomData('Brand');
-    } else {
-      // 전체일 때는 그냥 wholedata를 보여줌
-      setRandomData(getRandomItems(wholedata, 100));
-    }
-  }, [상품, 카테고리, 기획전, 브랜드]);
+    const loadMoreData = () => {
+      if (scrollvalue < 100) {
+        setScrollvalue(prevValue => prevValue + 12);
+      } else {
+        return; // loadMoreData function execution stopped
+      }
+    };
+  
+    const handleScroll = () => {
+      const { scrollTop, clientHeight, scrollHeight } = document.documentElement;
+      if (scrollTop + clientHeight >= scrollHeight - 5) {
+        loadMoreData();
+      }
+    };
+  
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [scrollvalue]);
+
+  let filteredData;
+  if (type === 'Product' || type === 'Category' || type === 'Exhibition' || type === 'Brand') {
+    filteredData = filterItemsByType(type);
+  } else {
+    filteredData = wholedata;
+  }
 
   return (
     <div>
-      <Filter
-        전체={전체}
-        set전체={set전체}
-        상품={상품}
-        set상품={set상품}
-        카테고리={카테고리}
-        set카테고리={set카테고리}
-        기획전={기획전}
-        set기획전={set기획전}
-        브랜드={브랜드}
-        set브랜드={set브랜드}
-        />
-         <ul className="itemlist">
-    {randomData.map((item) => (
-      <Item key={item.id} {...item} />
-    ))}
-  </ul>
-
-  <button onClick={() => console.log(wholedata)}>확인</button>
-</div>);
+      <Filter type={type} setType={setType} />
+      <ul className="itemlist">
+        {getRandomItems(filteredData, scrollvalue).map((item) => (
+          <Item key={item.id} {...item} />
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 export default Product;

--- a/shopping/src/store.js
+++ b/shopping/src/store.js
@@ -1,20 +1,24 @@
 import { configureStore, createSlice } from '@reduxjs/toolkit';
 
-let bookmark = createSlice({
+const bookmarkSlice = createSlice({
   name: 'bookmark',
-  initialState: {},
+  initialState: [],
   reducers: {
-    changeState(state, action) {
-      const { itemId } = action.payload;
-      state[itemId] = !state[itemId];
+    addToBookmark: (state, action) => {
+      state.push(action.payload);
+    },
+    removeFromBookmark: (state, action) => {
+      return state.filter((item) => item.id !== action.payload);
     },
   },
 });
 
-export default configureStore({
+export const { addToBookmark, removeFromBookmark } = bookmarkSlice.actions;
+
+const store = configureStore({
   reducer: {
-    bookmark: bookmark.reducer,
+    bookmark: bookmarkSlice.reducer,
   },
 });
 
-export const { changeState } = bookmark.actions;
+export default store;


### PR DESCRIPTION
1.상태관리 데이터를 5가지로관리하던것을 코멘트에따라 1가지 상태로 관리할수있게끔 수정

2. 메인상품리스트 페이지 스크롤시 페이지 로드기능추가
(의문점??)
scrollTop, clientHeight, scrollHeight 등 DOM내부 직접접근으로 위값의 변동여부를통해 스크롤이벤트가 언제실행될지 정해주고
리턴해주는 배열의 splice숫자를 12씩더해줘서 추가상품을 보여주도록하는식으로 만들었고 ,상품데이터가 100개가되면 동작이멈춤

3. 이런식으로 구현하는게맞나..?
(단점)
1) 스크롤위치가 계속 맨처음상태로돌아감

2) filter기능을이용한 상품을 보여줄때 모두같은배열에서 필터링해주다보니까 만약 전체 페이지에서 스크롤을통해 데이터를 여러개 이미 받아와버리면 다른 필터링페이지를 클릭했을떄 나는 상품을 더볼생각이없어도 이미배열내에 상품이 추가되어 상품을 더보여주게됨.

3)  데이터가많아질수록 문제가많이생길거같다.

